### PR TITLE
Make package compatible with LunarPHP ^1.0 and Laravel Mollie ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
     ],
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^9.0|^10.0",
-        "lunarphp/lunar": "^0.4|^0.5|^0.6|^0.7|^0.8",
-        "livewire/livewire": "^2.0",
-        "mollie/laravel-mollie": "^2.25"
+        "laravel/framework": "^10.0|^11.0",
+        "lunarphp/lunar": "^0.4|^0.5|^0.6|^0.7|^0.8|^1.0.0-beta.6",
+        "livewire/livewire": "^3.0",
+        "mollie/laravel-mollie": "^v3.0.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.4",

--- a/src/MolliePaymentType.php
+++ b/src/MolliePaymentType.php
@@ -9,12 +9,13 @@ use Lunar\Models\Order;
 use Lunar\Models\Transaction;
 use Lunar\PaymentTypes\AbstractPayment;
 use Mollie\Api\Exceptions\ApiException;
+use Mollie\Api\MollieApiClient;
 use Mollie\Api\Resources\Payment;
 use Mollie\Laravel\Wrappers\MollieApiWrapper;
 
 class MolliePaymentType extends AbstractPayment
 {
-    public function __construct(protected MollieApiWrapper $mollie)
+    public function __construct(protected MollieApiClient $mollie)
     {
     }
 

--- a/src/MolliePaymentsServiceProvider.php
+++ b/src/MolliePaymentsServiceProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
 use Lunar\Facades\Payments;
 use Mollie\Api\MollieApiClient;
-use Mollie\Laravel\Wrappers\MollieApiWrapper;
 use Webcraft\Lunar\Mollie\Components\PaymentForm;
 
 class MolliePaymentsServiceProvider extends ServiceProvider
@@ -24,8 +23,8 @@ class MolliePaymentsServiceProvider extends ServiceProvider
             return $app->make(MolliePaymentType::class);
         });
 
-        $this->app->singleton(MollieApiWrapper::class, function ($app) {
-            $mollie = new MollieApiWrapper($app->make('config'), $app->make(MollieApiClient::class));
+        $this->app->singleton(MollieApiClient::class, function ($app) {
+            $mollie = new MollieApiClient();
 
             if (!config('lunar.mollie.test_mode')) {
                 $mollie->setApiKey(config('lunar.mollie.live_key'));


### PR DESCRIPTION
This pull request updates the package to be compatible with Lunar 1.0-beta and Laravel Mollie 3.0. I've tested the code changes with LunarPHP 1.0.0-beta.6 and the payment went through as expected.